### PR TITLE
Add Swedish DCF valuation engine with Streamlit and CLI

### DIFF
--- a/dcf_sweden/README.md
+++ b/dcf_sweden/README.md
@@ -1,0 +1,35 @@
+# Swedish DCF Valuation App
+
+This project provides a minimal yet functional discounted cash-flow (DCF) valuation tool focused on Swedish equities.
+It offers both a Streamlit web interface and a command line interface.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+### Streamlit
+
+```bash
+streamlit run app.py
+```
+
+### CLI
+
+```bash
+python cli.py --ticker VOLV-B.ST --revenue 400000000000 430000000000 450000000000 --method perpetuity --g 0.02
+```
+
+Outputs are written to `./outputs` by default.
+
+## Data Sources
+
+The app relies on [yfinance](https://github.com/ranaroussi/yfinance) for market and financial data. All values are converted to SEK
+using Yahoo Finance FX tickers when necessary.
+
+## Disclaimer
+
+This tool is for educational purposes only and should not be considered investment advice.

--- a/dcf_sweden/__init__.py
+++ b/dcf_sweden/__init__.py
@@ -1,0 +1,1 @@
+"""Swedish DCF valuation package."""

--- a/dcf_sweden/app.py
+++ b/dcf_sweden/app.py
@@ -1,0 +1,57 @@
+"""Streamlit application entry point."""
+from __future__ import annotations
+
+import streamlit as st
+
+from .constants import DEFAULT_MRP_SE, DEFAULT_RF_PLACEHOLDER, DEFAULT_TAX_RATE_SE
+from .dcf import (
+    compute_fcff,
+    compute_wacc,
+    enterprise_value_from_fcff,
+    equity_value_from_ev,
+    per_share_value,
+    terminal_value_perpetuity,
+)
+from .formatting import format_currency
+
+
+st.set_page_config(page_title="Swedish DCF", layout="wide")
+
+st.sidebar.header("Inputs")
+ticker = st.sidebar.text_input("Ticker", "VOLV-B.ST")
+horizon = st.sidebar.slider("Forecast horizon", 3, 10, 5)
+g = st.sidebar.number_input("Terminal growth g", 0.0, 0.05, 0.02, step=0.005)
+rf = st.sidebar.number_input("Risk-free rate", 0.0, 0.1, DEFAULT_RF_PLACEHOLDER, step=0.005)
+beta = st.sidebar.number_input("Beta", 0.0, 3.0, 1.0, step=0.1)
+mrp = st.sidebar.number_input("Market risk premium", 0.0, 0.2, DEFAULT_MRP_SE, step=0.005)
+size_premium = st.sidebar.number_input("Size premium", 0.0, 0.05, 0.0, step=0.001)
+cod = st.sidebar.number_input("Cost of debt (pre-tax)", 0.0, 0.2, 0.03, step=0.005)
+tax = st.sidebar.number_input("Tax rate", 0.0, 1.0, DEFAULT_TAX_RATE_SE, step=0.01)
+eb_margin = st.sidebar.number_input("EBIT margin", -0.5, 0.5, 0.1, step=0.01)
+revenue = st.sidebar.number_input("Last revenue", 0.0, 1e9, 100_000_000.0, step=1_000_000.0)
+revgrowth = st.sidebar.number_input("Revenue growth", -0.2, 0.5, 0.05, step=0.01)
+da_pct = st.sidebar.number_input("D&A %", 0.0, 0.2, 0.05, step=0.005)
+capex_pct = st.sidebar.number_input("Capex %", 0.0, 0.2, 0.05, step=0.005)
+deltawnc_pct = st.sidebar.number_input("ΔNWC %", -0.1, 0.2, 0.01, step=0.005)
+net_debt = st.sidebar.number_input("Net debt", -1e9, 1e9, 0.0, step=1_000_000.0)
+shares = st.sidebar.number_input("Diluted shares", 0.0, 1e12, 100_000_000.0, step=1000.0)
+
+if st.sidebar.button("Run DCF"):
+    revenues = [revenue * (1 + revgrowth) ** i for i in range(1, horizon + 1)]
+    ebit = [r * eb_margin for r in revenues]
+    da = [r * da_pct for r in revenues]
+    capex = [r * capex_pct for r in revenues]
+    deltawnc = [r * deltawnc_pct for r in revenues]
+    fcffs = [compute_fcff(e, tax, d, c, w) for e, d, c, w in zip(ebit, da, capex, deltawnc)]
+
+    wacc = compute_wacc(rf, beta, mrp, size_premium, cod, tax, 1, 0)
+    tv = terminal_value_perpetuity(fcffs[-1] * (1 + g), wacc, g)
+    ev = enterprise_value_from_fcff(fcffs, wacc, tv)
+    eq = equity_value_from_ev(ev, net_debt)
+    ps = per_share_value(eq, shares)
+
+    st.subheader("Results")
+    st.metric("Enterprise Value", format_currency(ev))
+    st.metric("Equity Value", format_currency(eq))
+    st.metric("Intrinsic Value / share", format_currency(ps))
+

--- a/dcf_sweden/assumptions.py
+++ b/dcf_sweden/assumptions.py
@@ -1,0 +1,71 @@
+"""Heuristics to derive default assumptions from historical data."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+from .constants import DEFAULT_MRP_SE, DEFAULT_TAX_RATE_SE
+
+
+def clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+def revenue_cagr(revenues: Iterable[float]) -> float:
+    """Compute geometric CAGR for a sequence of revenues."""
+    rev = [r for r in revenues if r > 0]
+    if len(rev) < 2:
+        return 0.0
+    start, end = rev[0], rev[-1]
+    years = len(rev) - 1
+    return (end / start) ** (1 / years) - 1
+
+
+def avg_margin(series: Iterable[float], revenues: Iterable[float]) -> float:
+    """Return average margin of series / revenues."""
+    rev = np.array(revenues, dtype=float)
+    ser = np.array(series, dtype=float)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        margins = np.where(rev != 0, ser / rev, np.nan)
+    margins = margins[~np.isnan(margins)]
+    if len(margins) == 0:
+        return 0.0
+    return float(np.mean(margins))
+
+
+def propose_da_pct(da: Iterable[float], revenues: Iterable[float]) -> float:
+    return clamp(avg_margin(da, revenues), 0.0, 0.2)
+
+
+def propose_capex_pct(capex: Iterable[float], revenues: Iterable[float], da_pct: float) -> float:
+    capex_pct = clamp(avg_margin(capex, revenues), 0.0, 0.2)
+    return max(capex_pct, da_pct)
+
+
+def propose_delta_nwc_pct(deltawnc: Iterable[float], revenues: Iterable[float]) -> float:
+    pct = avg_margin(deltawnc, revenues)
+    return clamp(pct, -0.05, 0.15)
+
+
+def propose_tax_rate() -> float:
+    return DEFAULT_TAX_RATE_SE
+
+
+def propose_mrp() -> float:
+    return DEFAULT_MRP_SE
+
+
+@dataclass
+class Assumptions:
+    revenue_growth: float
+    ebit_margin: float
+    da_pct: float
+    capex_pct: float
+    deltawnc_pct: float
+    tax_rate: float
+    mrp: float
+
+

--- a/dcf_sweden/charts.py
+++ b/dcf_sweden/charts.py
@@ -1,0 +1,32 @@
+"""Plot helpers for Streamlit or CLI usage."""
+from __future__ import annotations
+
+import numpy as np
+import plotly.express as px
+
+from .formatting import as_percent
+
+
+def heatmap_wacc_g(wacc_values, g_values, data: np.ndarray):
+    fig = px.imshow(
+        data,
+        x=[as_percent(w) for w in wacc_values],
+        y=[as_percent(g) for g in g_values],
+        origin="lower",
+        labels=dict(x="WACC", y="g", color="Terminal Value"),
+    )
+    fig.update_layout(height=400)
+    return fig
+
+
+def heatmap_wacc_exit(wacc_values, exit_values, data: np.ndarray):
+    fig = px.imshow(
+        data,
+        x=[as_percent(w) for w in wacc_values],
+        y=[f"{m}x" for m in exit_values],
+        origin="lower",
+        labels=dict(x="WACC", y="Exit EV/EBITDA", color="PV of TV"),
+    )
+    fig.update_layout(height=400)
+    return fig
+

--- a/dcf_sweden/cli.py
+++ b/dcf_sweden/cli.py
@@ -1,0 +1,95 @@
+"""Command line interface for the Swedish DCF app."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+import numpy as np
+
+from .assumptions import Assumptions
+from .constants import DEFAULT_MRP_SE, DEFAULT_RF_PLACEHOLDER, DEFAULT_TAX_RATE_SE
+from .dcf import (
+    compute_fcff,
+    compute_wacc,
+    enterprise_value_from_fcff,
+    equity_value_from_ev,
+    per_share_value,
+    terminal_value_perpetuity,
+    terminal_value_exit_multiple,
+)
+from .formatting import format_currency, table_to_csv
+
+
+def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="FCFF-based DCF for Swedish equities")
+    p.add_argument("--ticker", required=True)
+    p.add_argument("--horizon", type=int, default=5)
+    p.add_argument("--method", choices=["perpetuity", "exit"], default="perpetuity")
+    p.add_argument("--g", type=float, default=0.02)
+    p.add_argument("--exit-multiple", type=float, default=10.0)
+    p.add_argument("--rf", type=float, default=DEFAULT_RF_PLACEHOLDER)
+    p.add_argument("--beta", type=float, default=1.0)
+    p.add_argument("--mrp", type=float, default=DEFAULT_MRP_SE)
+    p.add_argument("--size-premium-bps", dest="size_premium_bps", type=float, default=0.0)
+    p.add_argument("--cod", type=float, default=0.03)
+    p.add_argument("--tax", type=float, default=DEFAULT_TAX_RATE_SE)
+    p.add_argument("--capex-pct", type=float, default=0.05)
+    p.add_argument("--da-pct", type=float, default=0.05)
+    p.add_argument("--deltawnc-pct", type=float, default=0.01)
+    p.add_argument("--revenue", type=float, nargs="+", required=True, help="Historical revenue sequence for CAGR")
+    p.add_argument("--ebit-margin", type=float, default=0.1)
+    p.add_argument("--net-debt", type=float, default=0.0)
+    p.add_argument("--shares", type=float, default=1.0)
+    p.add_argument("--export-dir", default="./outputs")
+    return p.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> None:
+    args = parse_args(argv)
+
+    # Forecast revenues
+    last_revenue = args.revenue[-1]
+    revenues = [last_revenue * (1 + args.g) ** i for i in range(1, args.horizon + 1)]
+
+    ebit = [r * args.ebit_margin for r in revenues]
+    da = [r * args.da_pct for r in revenues]
+    capex = [r * args.capex_pct for r in revenues]
+    deltawnc = [r * args.deltawnc_pct for r in revenues]
+
+    fcffs = [
+        compute_fcff(e, args.tax, d, c, w) for e, d, c, w in zip(ebit, da, capex, deltawnc)
+    ]
+
+    wacc = compute_wacc(args.rf, args.beta, args.mrp, args.size_premium_bps / 10000, args.cod, args.tax, 1, 0)
+
+    if args.method == "perpetuity":
+        tv = terminal_value_perpetuity(fcffs[-1] * (1 + args.g), wacc, args.g)
+    else:
+        tv = terminal_value_exit_multiple(ebit[-1] + da[-1], args.exit_multiple)
+
+    ev = enterprise_value_from_fcff(fcffs, wacc, tv)
+    eq = equity_value_from_ev(ev, args.net_debt)
+    ps = per_share_value(eq, args.shares)
+
+    print(f"Intrinsic value per share: {format_currency(ps)}")
+
+    export_path = Path(args.export_dir)
+    export_path.mkdir(parents=True, exist_ok=True)
+    csv = table_to_csv(
+        ["Year", "Revenue", "EBIT", "FCFF"],
+        zip(range(1, args.horizon + 1), revenues, ebit, fcffs),
+    )
+    (export_path / f"{args.ticker}_forecast.csv").write_text(csv)
+
+    summary = {
+        "ticker": args.ticker,
+        "per_share_value": ps,
+    }
+    (export_path / f"{args.ticker}_summary.json").write_text(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()
+

--- a/dcf_sweden/constants.py
+++ b/dcf_sweden/constants.py
@@ -1,0 +1,24 @@
+"""Project-wide constants for Swedish DCF valuation."""
+
+from __future__ import annotations
+
+# Corporate tax rate in Sweden (2023)
+DEFAULT_TAX_RATE_SE: float = 0.206
+
+# Market risk premium assumption for Sweden
+DEFAULT_MRP_SE: float = 0.055
+
+# Placeholder for the risk-free rate (user should update in UI/CLI)
+DEFAULT_RF_PLACEHOLDER: float = 0.02
+
+# Common FX tickers for conversion to SEK when using yfinance
+DEFAULT_FX_TICKERS = {
+    "USD": "USDSEK=X",
+    "EUR": "EURSEK=X",
+}
+
+# Sensitivity grid defaults
+WACC_SENSITIVITY = [x / 100 for x in range(600, 1201, 50)]  # 6% -> 12% step 0.5%
+G_SENSITIVITY = [x / 10000 for x in range(0, 251, 25)]  # 0% -> 2.5% step 0.25%
+EXIT_MULTIPLE_SENSITIVITY = list(range(6, 15))  # 6x -> 14x
+

--- a/dcf_sweden/data.py
+++ b/dcf_sweden/data.py
@@ -1,0 +1,85 @@
+"""Data access layer using yfinance."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import pandas as pd
+
+try:  # pragma: no cover - optional dependency
+    import yfinance as yf
+except Exception:  # pragma: no cover
+    yf = None
+
+from .constants import DEFAULT_FX_TICKERS
+
+
+@dataclass
+class MarketData:
+    price: float
+    currency: str
+    shares_outstanding: float
+    market_cap: float
+
+
+@dataclass
+class FinancialStatements:
+    income_statement: pd.DataFrame
+    balance_sheet: pd.DataFrame
+    cash_flow: pd.DataFrame
+
+
+def fetch_market_data(ticker: str) -> MarketData:
+    """Fetch latest market data for a ticker."""
+    if yf is None:
+        raise RuntimeError("yfinance is required for market data fetching")
+    info = yf.Ticker(ticker).info
+    return MarketData(
+        price=info.get("regularMarketPrice"),
+        currency=info.get("currency", "SEK"),
+        shares_outstanding=info.get("sharesOutstanding", 0.0),
+        market_cap=info.get("marketCap", 0.0),
+    )
+
+
+def fetch_financials(ticker: str) -> FinancialStatements:
+    """Return financial statements for a ticker.
+
+    The function mirrors the structure from Yahoo Finance. It returns empty
+    DataFrames if the download fails to keep callers robust.
+    """
+    if yf is None:
+        raise RuntimeError("yfinance is required for financials fetching")
+    yft = yf.Ticker(ticker)
+    try:
+        income = yft.financials.T
+        balance = yft.balance_sheet.T
+        cash = yft.cashflow.T
+    except Exception:
+        income = pd.DataFrame()
+        balance = pd.DataFrame()
+        cash = pd.DataFrame()
+    return FinancialStatements(income, balance, cash)
+
+
+def fetch_fx_rate(from_currency: str, to_currency: str = "SEK") -> Optional[float]:
+    """Fetch latest FX rate using yfinance."""
+    if from_currency == to_currency:
+        return 1.0
+    if yf is None:
+        return None
+    ticker = DEFAULT_FX_TICKERS.get(from_currency.upper())
+    if ticker is None:
+        return None
+    data = yf.Ticker(ticker).history(period="1d")
+    if data.empty:
+        return None
+    return float(data["Close"].iloc[-1])
+
+
+def convert_to_sek(amount: float, currency: str) -> Optional[float]:
+    rate = fetch_fx_rate(currency, "SEK")
+    if rate is None:
+        return None
+    return amount * rate
+

--- a/dcf_sweden/dcf.py
+++ b/dcf_sweden/dcf.py
@@ -1,0 +1,102 @@
+"""Core DCF valuation engine."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+import numpy as np
+
+
+@dataclass
+class DCFResult:
+    enterprise_value: float
+    equity_value: float
+    per_share_value: float
+
+
+# --- FCFF ---------------------------------------------------------------
+
+def compute_fcff(ebit: float, tax_rate: float, da: float, capex: float, delta_nwc: float) -> float:
+    """Free cash flow to firm."""
+    return ebit * (1 - tax_rate) + da - capex - delta_nwc
+
+
+# --- WACC ---------------------------------------------------------------
+
+def cost_of_equity(rf: float, beta: float, mrp: float, size_premium: float = 0.0) -> float:
+    return rf + beta * (mrp + size_premium)
+
+
+def cost_of_debt_after_tax(cod: float, tax_rate: float) -> float:
+    return cod * (1 - tax_rate)
+
+
+def compute_wacc(rf: float, beta: float, mrp: float, size_premium: float, cod: float, tax_rate: float, equity: float, debt: float) -> float:
+    coe = cost_of_equity(rf, beta, mrp, size_premium)
+    cod_at = cost_of_debt_after_tax(cod, tax_rate)
+    total = equity + debt
+    if total == 0:
+        return coe
+    return (equity / total) * coe + (debt / total) * cod_at
+
+
+# --- Terminal Value ----------------------------------------------------
+
+def terminal_value_perpetuity(fcff_next: float, wacc: float, g: float) -> float:
+    if g >= wacc:
+        raise ValueError("Terminal growth must be less than WACC")
+    return fcff_next / (wacc - g)
+
+
+def terminal_value_exit_multiple(ebitda: float, exit_multiple: float) -> float:
+    return ebitda * exit_multiple
+
+
+# --- PV calculations ---------------------------------------------------
+
+def discount_cash_flows(fcffs: Iterable[float], wacc: float) -> List[float]:
+    pvs = []
+    for t, fcff in enumerate(fcffs, start=1):
+        pvs.append(fcff / ((1 + wacc) ** t))
+    return pvs
+
+
+def enterprise_value_from_fcff(fcffs: Iterable[float], wacc: float, terminal_value: float) -> float:
+    pvs = discount_cash_flows(fcffs, wacc)
+    n = len(pvs)
+    ev = sum(pvs) + terminal_value / ((1 + wacc) ** n)
+    return ev
+
+
+def equity_value_from_ev(ev: float, net_debt: float, minority_interest: float = 0.0, investments: float = 0.0) -> float:
+    return ev - net_debt - minority_interest + investments
+
+
+def per_share_value(equity_value: float, shares_outstanding: float) -> float:
+    if shares_outstanding <= 0:
+        return float("nan")
+    return equity_value / shares_outstanding
+
+
+# --- Sensitivities -----------------------------------------------------
+
+def sensitivity_wacc_g(fcff_last: float, wacc_values: Iterable[float], g_values: Iterable[float]) -> np.ndarray:
+    grid = np.zeros((len(g_values), len(wacc_values)))
+    for i, g in enumerate(g_values):
+        for j, wacc in enumerate(wacc_values):
+            try:
+                grid[i, j] = terminal_value_perpetuity(fcff_last * (1 + g), wacc, g)
+            except ValueError:
+                grid[i, j] = np.nan
+    return grid
+
+
+def sensitivity_wacc_exit(ebitda: float, wacc_values: Iterable[float], exit_multiples: Iterable[float]) -> np.ndarray:
+    grid = np.zeros((len(exit_multiples), len(wacc_values)))
+    for i, multiple in enumerate(exit_multiples):
+        tv = terminal_value_exit_multiple(ebitda, multiple)
+        for j, wacc in enumerate(wacc_values):
+            grid[i, j] = tv / (1 + wacc) ** len(wacc_values)
+    return grid
+
+

--- a/dcf_sweden/examples/example_inputs.json
+++ b/dcf_sweden/examples/example_inputs.json
@@ -1,0 +1,15 @@
+{
+  "ticker": "VOLV-B.ST",
+  "revenue": [400000000000, 430000000000, 450000000000],
+  "ebit_margin": 0.1,
+  "da_pct": 0.05,
+  "capex_pct": 0.05,
+  "deltawnc_pct": 0.01,
+  "rf": 0.02,
+  "beta": 1.1,
+  "mrp": 0.055,
+  "g": 0.02,
+  "horizon": 5,
+  "shares": 2030000000,
+  "net_debt": -10000000000
+}

--- a/dcf_sweden/formatting.py
+++ b/dcf_sweden/formatting.py
@@ -1,0 +1,30 @@
+"""Formatting helpers for currency and numbers."""
+from __future__ import annotations
+
+import math
+from typing import Iterable
+
+
+def format_currency(value: float, currency: str = "SEK", decimals: int = 0) -> str:
+    """Return a human readable currency string."""
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        return "-"
+    return f"{value:,.{decimals}f} {currency}"
+
+
+def as_percent(value: float, decimals: int = 1) -> str:
+    return f"{value * 100:.{decimals}f}%"
+
+
+def table_to_csv(headers: Iterable[str], rows: Iterable[Iterable]) -> str:
+    """Convert a table to CSV string."""
+    import csv
+    from io import StringIO
+
+    buf = StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(list(headers))
+    for row in rows:
+        writer.writerow(list(row))
+    return buf.getvalue()
+

--- a/dcf_sweden/requirements.txt
+++ b/dcf_sweden/requirements.txt
@@ -1,0 +1,6 @@
+streamlit
+pandas
+numpy
+yfinance
+plotly
+requests

--- a/dcf_sweden/tests/conftest.py
+++ b/dcf_sweden/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure package root on path
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/dcf_sweden/tests/test_assumptions.py
+++ b/dcf_sweden/tests/test_assumptions.py
@@ -1,0 +1,15 @@
+from dcf_sweden.assumptions import revenue_cagr, propose_capex_pct, propose_da_pct
+
+
+def test_revenue_cagr():
+    revs = [100, 110, 121]
+    assert abs(revenue_cagr(revs) - 0.10) < 1e-6
+
+
+def test_capex_pct():
+    revenues = [100, 100, 100]
+    da = [5, 5, 5]
+    capex = [4, 4, 4]
+    da_pct = propose_da_pct(da, revenues)
+    capex_pct = propose_capex_pct(capex, revenues, da_pct)
+    assert capex_pct == da_pct

--- a/dcf_sweden/tests/test_data.py
+++ b/dcf_sweden/tests/test_data.py
@@ -1,0 +1,11 @@
+from dcf_sweden import data
+
+
+def test_convert_to_sek(monkeypatch):
+    def fake_fetch_fx_rate(cur_from, to):
+        assert cur_from == "USD"
+        assert to == "SEK"
+        return 10.0
+
+    monkeypatch.setattr(data, "fetch_fx_rate", fake_fetch_fx_rate)
+    assert data.convert_to_sek(1.0, "USD") == 10.0

--- a/dcf_sweden/tests/test_dcf.py
+++ b/dcf_sweden/tests/test_dcf.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+from dcf_sweden.dcf import (
+    compute_fcff,
+    compute_wacc,
+    terminal_value_perpetuity,
+    enterprise_value_from_fcff,
+    equity_value_from_ev,
+    per_share_value,
+    sensitivity_wacc_g,
+)
+
+
+def test_fcff():
+    fcff = compute_fcff(100, 0.2, 10, 20, 5)
+    assert fcff == 100 * 0.8 + 10 - 20 - 5
+
+
+def test_wacc():
+    wacc = compute_wacc(0.02, 1.0, 0.05, 0.0, 0.03, 0.2, 60, 40)
+    coe = 0.02 + 1.0 * 0.05
+    cod_at = 0.03 * (1 - 0.2)
+    expected = 0.6 * coe + 0.4 * cod_at
+    assert abs(wacc - expected) < 1e-9
+
+
+def test_terminal_value_error():
+    try:
+        terminal_value_perpetuity(100, 0.05, 0.05)
+    except ValueError:
+        assert True
+    else:  # pragma: no cover - ensures error raised
+        assert False
+
+
+def test_valuation_flow():
+    fcffs = [100, 110, 120]
+    wacc = 0.1
+    tv = terminal_value_perpetuity(120 * 1.02, wacc, 0.02)
+    ev = enterprise_value_from_fcff(fcffs, wacc, tv)
+    eq = equity_value_from_ev(ev, net_debt=50)
+    ps = per_share_value(eq, 10)
+    assert ps > 0
+
+
+def test_sensitivity_shape():
+    grid = sensitivity_wacc_g(100, [0.07, 0.08], [0.01, 0.02, 0.025])
+    assert grid.shape == (3, 2)
+    assert grid[-1, 0] > 0


### PR DESCRIPTION
## Summary
- implement core FCFF-based DCF valuation logic with WACC, terminal value and sensitivity utilities
- add yfinance-powered data layer, default assumption heuristics and number formatting helpers
- provide Streamlit app, CLI interface, example inputs and unit tests

## Testing
- `pytest dcf_sweden/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689d09f838c08333adef9fa9618967cc